### PR TITLE
Uncomment missing lines necessary for rev. 2 board

### DIFF
--- a/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
+++ b/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
@@ -213,9 +213,9 @@ void loop()
     
     // set the pwm
     pwmA = pwmLevels[min(abs(levelA), maxA)];
-    //pwmPinA = levelA < 0 ? mcPin2A : mcPin1A; // drv8833
+    pwmPinA = levelA < 0 ? mcPin2A : mcPin1A; // drv8833
     pwmB = pwmLevels[min(abs(levelB), maxB)];
-    //pwmPinB = levelB < 0 ? mcPin2B : mcPin1B; // drv8833
+    pwmPinB = levelB < 0 ? mcPin2B : mcPin1B; // drv8833
     
     // rate limit
     serialRateLimiter = 8;


### PR DESCRIPTION
These lines were left commented out. This was causing the motor to increment speeds in reverse (i.e. 0-7-6-5-4-3-2-1) when going backward, but seemed okay when going forward.

The motor may have actually been spinning forward when backward was requested, but I didn't happen to see whether or not this was the case.
