### PR TITLE
Remove unreferenced variable

### DIFF
--- a/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
+++ b/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
@@ -175,7 +175,6 @@ void loop()
     {
       // select proper output
       char* levelX = incomingByte & 64 ? &levelB : &levelA;
-      int* pwmX = incomingByte & 64 ? &pwmB : &pwmA;
       if ((incomingByte & 63) < 29 || (incomingByte & 63) > 35)
       {
         // set the level


### PR DESCRIPTION
`pwmX` is never used. The compiler appears to optimize this away, but let's remove it anyway to keep the code as clean as possible.
