### PR TITLE
Fix bug when braking with drv8833

### DIFF
--- a/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
+++ b/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
@@ -313,8 +313,11 @@ void bitBangPwm(char thePwmPinA, int pwmA, char thePwmPinB, int pwmB)
     {
       delayMicroseconds(pwmB - pwmA);
     }
-    // channelB off
-    digitalWrite(thePwmPinB, LOW);
+    if (pwmB > 0)
+    {
+      // channelB off
+      digitalWrite(thePwmPinB, LOW);
+    }
     // finish out the cycle
     if (pwmB < uSecCyc)
       delayMicroseconds(uSecCyc - pwmB);
@@ -333,8 +336,11 @@ void bitBangPwm(char thePwmPinA, int pwmA, char thePwmPinB, int pwmB)
     {
       delayMicroseconds(pwmA - pwmB);
     }
-    // channelA off
-    digitalWrite(thePwmPinA, LOW);
+    if (pwmA > 0)
+    {
+      // channelA off
+      digitalWrite(thePwmPinA, LOW);
+    }
     // finish out the cycle
     if (pwmA < uSecCyc)
       delayMicroseconds(uSecCyc - pwmA);


### PR DESCRIPTION
Before this fix, channel B would get stuck in full forward when brake was requested on B and A was stopped (brake or float). After this fix, channel B brakes when brake is requested regardless of channel A's status. This preemptively fixes the same issue with channel A, although the surrounding conditional would never allow the issue to be seen on A.
