### PR TITLE
Write literal bytes instead of decimal representations

### DIFF
--- a/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
+++ b/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
@@ -196,7 +196,7 @@ void loop()
         digitalWrite(incomingByte & 64 ? mcPin2B : mcPin2A, HIGH);
       }
       // notify sender
-      softSerial.print(*levelX, DEC);
+      softSerial.write(*levelX);
     }
 
     // Combo output mode
@@ -211,7 +211,7 @@ void loop()
       // notify sender
       maskedByte = abs(levelB >> 2) + (levelB < 0 ? 8 : 0);
       maskedByte = (maskedByte << 4) + abs(levelA >> 2) + (levelA < 0 ? 8 : 0);
-      softSerial.print(maskedByte, DEC);
+      softSerial.write(maskedByte);
     }
     
     // set the pwm


### PR DESCRIPTION
The decimal representations ranged from 1 byte to 4 bytes in length. This is not good when the firmware is designed around sending/receiving as little as possible. Therefore, send the data, not the interpretation.
