### PR TITLE
Use HC-06 default baud rate

### DIFF
--- a/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
+++ b/8884bt Remote Control Receiver/firmware/brickster8884bt.ino
@@ -128,10 +128,9 @@ void setup()
 {
   // bluetooth control init
   pinMode(btResetPin, OUTPUT);
-  digitalWrite(btResetPin, LOW);  // reset Bluetooth module
-  delay(3); // verified minimum   // hold long enough to register reset
-  digitalWrite(btResetPin, HIGH); // end Bluetooth reset
-  delay(515); // verified minumim // wait until Bluetooth module is ready
+  // digitalWrite(btResetPin, LOW);  // reset Bluetooth module
+  // delay(3); // verified minimum   // hold long enough to register reset
+  // digitalWrite(btResetPin, HIGH); // end Bluetooth reset
   
   // channel A init
   pinMode(mcPin1A, OUTPUT);


### PR DESCRIPTION
The baud rate of 57600 was causing some stability issues. The ATtiny84's internal oscillator is too sensitive to the environment (mostly temperature) to use such a high rate. The default of 9600 should be just fine now that only one single byte is being sent for every byte received.

Additionally, the HC-06 did not always register the AT command to change baud rate, which was probably a timing issue. By using the default baud rate, we sidestep the issue of needing long boot times and a Bluetooth module reset to send that command.

I've left in, but commented out, the Bluetooth module reset code. It will be useful when adding the change-module-name functionality later.
